### PR TITLE
gnome 48 compability

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,8 @@
     "shell-version": [
         "45",
         "46",
-        "47"
+        "47",
+        "48"
     ],
     "gettext-domain": "AppIndicatorExtension",
     "settings-schema": "org.gnome.shell.extensions.appindicator",


### PR DESCRIPTION
## Summary by Sourcery

Add compatibility support for GNOME 48 by modifying the image content setting method in the app indicator implementation

New Features:
- Add version detection for GNOME 48 and above

Enhancements:
- Update image content setting method to support GNOME 48+ by conditionally adding a Cogl context parameter